### PR TITLE
feat - Add a post install script

### DIFF
--- a/lib/post_install.js
+++ b/lib/post_install.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+// adapted based on rackt/history (MIT)
+// Node 4+
+var execSync = require('child_process').execSync;
+var stat = require('fs').stat;
+
+function exec(command) {
+  execSync(command, {
+    stdio: [0, 1, 2]
+  });
+}
+
+stat('dist', function(error, stat) {
+  // Skip building on Travis
+  if (process.env.TRAVIS) {
+    return;
+  }
+
+  if (error || !stat.isDirectory()) {
+    exec('npm install --only=dev');
+    exec('npm run build');
+  }
+});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "bin": "dist/index.js",
   "files": [
     "dist",
+    "lib",
     "templates",
     "config.json"
   ],
@@ -23,6 +24,7 @@
     "lint": "eslint --cache src test",
     "test": "jest",
     "prebuild": "npm run clean:dist",
+    "postinstall": "node lib/post_install.js",
     "build": "cross-env NODE_ENV=production babel -s true src -d dist --ignore 'src/**/*.test.js'",
     "clean:dist": "del-cli dist",
     "start": "npm run serve:dev src",


### PR DESCRIPTION
This generates a build if it's missing. Now you can consume defaults outside of npm through revisions/tags.