### PR TITLE
fix(babel): transpile ES6 to CJS modules

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,7 @@
     [
       "env",
       {
-        "modules": false,
+        "modules": "commonjs",
         "useBuiltIns": true,
         "targets": {
           "node": 4.3

--- a/src/tasks/babel.js
+++ b/src/tasks/babel.js
@@ -6,7 +6,7 @@ module.exports = (config) => {
     .merge({
       presets: [
         ['env', {
-          modules: commonjs,
+          modules: 'commonjs',
           useBuiltIns: true,
           // Target maintained to match minimum Webpack Nodejs version.
           targets: { node: config.minNode },

--- a/src/tasks/babel.js
+++ b/src/tasks/babel.js
@@ -6,7 +6,6 @@ module.exports = (config) => {
     .merge({
       presets: [
         ['env', {
-          modules: false,
           modules: commonjs,
           useBuiltIns: true,
           // Target maintained to match minimum Webpack Nodejs version.

--- a/src/tasks/babel.js
+++ b/src/tasks/babel.js
@@ -7,6 +7,7 @@ module.exports = (config) => {
       presets: [
         ['env', {
           modules: false,
+          modules: commonjs,
           useBuiltIns: true,
           // Target maintained to match minimum Webpack Nodejs version.
           targets: { node: config.minNode },


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

ES6 Modules won't work within the context of loader-runner. This change transpiles ES6 imports down to `require()`.

Relates to #23