### PR TITLE
feat: add commonjs proxy for es modules

### DIFF
--- a/src/tasks/package.js
+++ b/src/tasks/package.js
@@ -49,7 +49,7 @@ module.exports = (config) => {
         'travis:lint': 'yarn run lint && yarn run security',
         'travis:test': 'yarn run test',
       },
-      main: 'dist/index.js',
+      main: 'dist/cjs.js',
       files: [
         'dist',
       ],

--- a/templates/src/cjs.js
+++ b/templates/src/cjs.js
@@ -1,0 +1,1 @@
+module.exports = require('./index').default;


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

Adds a CommonJS proxy to handle the `export default` issue while retaining the ability to use ES Modules internally.

Closes #23 