### PR TITLE
fix: add missing cjs.js to filesOnce

### DIFF
--- a/src/tasks/templates.js
+++ b/src/tasks/templates.js
@@ -11,6 +11,7 @@ const files = [
 // These files will by created only once
 const filesOnce = [
   'src/index.js',
+  'src/cjs.js',
   'CHANGELOG.md',
 ];
 


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

The template was added but I forgot to add it to `templates.js` so it's actually written out.

Closes #44 