### PR TITLE
chore(travis): Bump webpack test version

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,6 +9,6 @@
         "travis",
         "package"
     ],
-    "webpackVersion": "2.2.0",
+    "webpackVersion": "2.6.0",
     "minNode": "4.3"
 }


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

Increases the defined webpack version used for testing in the `.travis.yml` to the currently released minor version of `2.6.0`