### PR TITLE
fix: Release script should not exec `npm run`

### DIFF
--- a/src/tasks/package.js
+++ b/src/tasks/package.js
@@ -45,7 +45,7 @@ module.exports = (config) => {
         'lint-staged': 'lint-staged',
         prebuild: 'npm run clean',
         prepublish: 'npm run build',
-        release: 'npm run standard-version',
+        release: 'standard-version',
         security: 'nsp check',
         test: 'jest',
         'test:watch': 'jest --watch',


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

`release` should just execute the standard-version bin. It's currently trying to execute an npm script with the same name.