### PR TITLE
feat: Enforce peerDependencies via defaults

### DIFF
--- a/src/tasks/package.js
+++ b/src/tasks/package.js
@@ -36,6 +36,9 @@ module.exports = (config) => {
         // Some versions are skipped because of known issues, see https://github.com/webpack-contrib/organization/issues/7
         node: `>= ${config.minNode} < 5.0.0 || >= 5.10`,
       },
+      peerDependencies: {
+        webpack: `^2.0.0 || >= 3.0.0-rc.0 || ^3.0.0`,
+      },
       scripts: {
         start: 'npm run build -- -w',
         'appveyor:test': 'npm run test',

--- a/src/tasks/package.js
+++ b/src/tasks/package.js
@@ -37,7 +37,7 @@ module.exports = (config) => {
         node: `>= ${config.minNode} < 5.0.0 || >= 5.10`,
       },
       peerDependencies: {
-        webpack: `^2.0.0 || >= 3.0.0-rc.0 || ^3.0.0`,
+        webpack: '^2.0.0 || >= 3.0.0-rc.0 || ^3.0.0',
       },
       scripts: {
         start: 'npm run build -- -w',


### PR DESCRIPTION
 - These may end up being customized over time per project but they should be there with this as the current default.

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

Adds a peerDependency for Webpack effectively dropping support for 1.x with the application of webpack-defaults.

Closes #63 