### PR TITLE
fix: Adds missing appveyor task in config

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,6 +7,7 @@
         "babel",
         "eslint",
         "travis",
+        "appveyor",
         "package"
     ],
     "webpackVersion": "2.6.0",


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

Wasn't added with the template.