### PR TITLE
fix: Include was using the deprecated nodejs key

### DIFF
--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -11,11 +11,11 @@ jobs:
   include:
     - &test-latest
       stage: Webpack latest
-      nodejs: 6
+      node_js: 6
       env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
     - <<: *test-latest
-      nodejs: 4.3
+      node_js: 4.3
       env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
     - <<: *test-latest


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

Template is currently using `nodejs` as a key for the new stages config which is deprecated.