### PR TITLE
refactor: remove `webpack v3.0.0-rc` from `peerDependencies`

### DIFF
--- a/src/tasks/package.js
+++ b/src/tasks/package.js
@@ -37,7 +37,7 @@ module.exports = (config) => {
         node: `>= ${config.minNode} < 5.0.0 || >= 5.10`,
       },
       peerDependencies: {
-        webpack: '^2.0.0 || >= 3.0.0-rc.0 || ^3.0.0',
+        webpack: '^2.0.0 || ^3.0.0',
       },
       scripts: {
         start: 'npm run build -- -w',


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

As per the comment from https://github.com/webpack-contrib/less-loader/pull/208#discussion_r123869314