### PR TITLE
feat: add `webpack` as a `devDependency`

### DIFF
--- a/src/tasks/package.js
+++ b/src/tasks/package.js
@@ -23,7 +23,7 @@ const packages = [
   'eslint-config-webpack',
   'lint-staged',
   'pre-commit',
-  
+
   // Webpack
   'webpack',
 ];

--- a/src/tasks/package.js
+++ b/src/tasks/package.js
@@ -23,6 +23,9 @@ const packages = [
   'eslint-config-webpack',
   'lint-staged',
   'pre-commit',
+  
+  // Webpack
+  'webpack',
 ];
 
 module.exports = (config) => {


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

Continuing the discussion from https://github.com/webpack-contrib/less-loader/pull/208#discussion_r123879351

I believe webpack should be included as a dev dependency because:
* checking out a webpack-contrib repo, running `npm install` and `npm t` should just work. Instead you're greeted with this error message, it's not immediately obvious that webpack needs to be installed with `npm install webpack`. Some users will just give up here and not bother contributing to the repo.
<img width="607" alt="screen shot 2017-06-25 at 10 59 41" src="https://user-images.githubusercontent.com/6425649/27515161-6de4ec5c-5995-11e7-8c20-bc1688745b04.png">

* secondly once running `npm install webpack` to get the tests running, because of the npm 5 requirement, `package.json` and `package-lock.json` are automatically updated and will appear in the git diff before the user has even made any changes. Based on my own experience with open source, people will commit these changes in a pull request, and it's going to lead to maintainers asking contributors to remove these files in reviews which is just a waste of everyones time and energy. 

I can't really see any advantages to not having it installed as a dev dependency, travis already automatically tests the repo against all supported versions of webpack and will catch the rare time something is broken on an older version of webpack.

Closes #78 