### PR TITLE
fix: ensure `jest-cli` is installed

### DIFF
--- a/src/tasks/package.js
+++ b/src/tasks/package.js
@@ -9,6 +9,7 @@ const packages = [
 
   // Jest
   'jest',
+  'jest-cli',
   'babel-jest',
 
   // Babel


### PR DESCRIPTION
When running webpack-defaults earlier I wasn't able to run the tests without adding `jest-cli` as a dev dependency. I guess most people have it installed globally which is why it's not come up before.