### PR TITLE
fix(appveyor): always use latest npm

### DIFF
--- a/src/tasks/appveyor.js
+++ b/src/tasks/appveyor.js
@@ -38,6 +38,7 @@ module.exports = (config) => {
       },
       install: [
         'ps: Install-Product node $env:nodejs_version x64',
+        'npm i -g npm@latest',
         'npm install',
       ],
       before_test: [


### PR DESCRIPTION
Node 4.3 uses npm2 which doesn't hoist dependencies, so then you get cryptic error messages on appveyor about regeneratorRuntime not being defined when using async functions in tests. Travis already forces npm5 so we may as well enforce it here as well.