### PR TITLE
feat: update minimum required `node.js` version to `4.8` for travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       node_js: '8'
       env: WEBPACK_VERSION="2.6.0" JOB_PART=lint
     - os: linux
-      node_js: '4.3'
+      node_js: '4.8'
       env: WEBPACK_VERSION="2.6.0" JOB_PART=test
     - os: linux
       node_js: '6'

--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
     - <<: *test-latest
-      node_js: 4.3
+      node_js: 4.8
       env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
     - <<: *test-latest


### PR DESCRIPTION
Based on https://github.com/webpack-contrib/file-loader/pull/183#issuecomment-328289654.
Issue around `npm` - https://github.com/npm/npm/issues/18395.
From `slack`:
```shell
sokra [12:29 PM] 
we are no longer chained to 4.3. You can use that lastest 4.x (node.js version currently in maintenance mode.
4.3 was because of AWS, but they upgraded to node 6.x so this is no longer an issue.
```
