### PR TITLE
refactor: restructure package.json+template semantically

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,19 +2,18 @@
   "name": "webpack-defaults",
   "version": "2.0.0",
   "description": "Defaults to be shared across webpack projects",
-  "main": "dist/cjs.js",
-  "files": [
-    "bin",
-    "dist",
-    "lib",
-    "src",
-    "templates",
-    "config.json"
-  ],
-  "engines": {
-    "node": ">= 6.9.0 || >= 8.9.0"
+  "license": "MIT",
+  "repository": "webpack-contrib/webpack-defaults",
+  "author": {
+    "name": "Artem Sapegin",
+    "url": "http://sapegin.me"
   },
+  "homepage": "https://github.com/webpack-contrib/webpack-defaults",
+  "main": "dist/cjs.js",
   "bin": "bin/index.js",
+  "engines": {
+    "node": ">= 6.9.0"
+  },
   "scripts": {
     "start": "npm run serve:dev src",
     "lint": "eslint --cache src test",
@@ -35,6 +34,17 @@
     "travis:test": "npm run test -- --runInBand",
     "defaults": "./bin/index.js"
   },
+  "files": [
+    "bin",
+    "dist",
+    "lib",
+    "src",
+    "templates",
+    "config.json"
+  ],
+  "keywords": [
+    "webpack"
+  ],
   "dependencies": {
     "chalk": "^2.3.0",
     "git-username": "^0.5.0",
@@ -61,21 +71,12 @@
     "prettier": "^1.9.2",
     "standard-version": "^4.2.0"
   },
+
   "pre-commit": "lint-staged",
   "lint-staged": {
     "*.js": [
       "eslint --fix",
       "git add"
     ]
-  },
-  "author": {
-    "name": "Artem Sapegin",
-    "url": "http://sapegin.me"
-  },
-  "keywords": [
-    "webpack"
-  ],
-  "homepage": "https://github.com/webpack-contrib/webpack-defaults",
-  "repository": "webpack-contrib/webpack-defaults",
-  "license": "MIT"
+  }
 }

--- a/src/tasks/package.js
+++ b/src/tasks/package.js
@@ -55,11 +55,16 @@ module.exports = (config) => {
     .set({
       name: `${packageName}`,
       version: existing.version || '1.0.0',
-      author: existing.author || `${name}`,
       description: existing.description || '',
       license: existing.license || 'MIT',
-      main: 'dist/cjs.js',
-      files: ['dist'],
+      repository: `${repository}`,
+      author: existing.author || `${name}`,
+      homepage: `https://github.com/${repository}`,
+      bugs: `https://github.com/${repository}/issues`,
+      main: existing.main || 'dist/cjs.js',
+      engines: {
+        node: `>= ${config.maintLTS}`,
+      },
       scripts: {
         start: 'npm run build -- -w',
         build:
@@ -86,17 +91,10 @@ module.exports = (config) => {
         'ci:coverage': 'npm run test:coverage -- --runInBand',
         defaults: 'webpack-defaults',
       },
+      files: existing.files || ['dist/', 'lib/', 'index.js'],
+      peerDependencies: existing.peerDependencies || { webpack: '^4.3.0' },
       dependencies: existing.dependencies || {},
       devDependencies: existing.devDependencies || {},
-      engines: {
-        node: `>= ${config.maintLTS} || >= ${config.activeLTS}`,
-      },
-      peerDependencies: {
-        webpack: `^${config.maintWebpack} || ^${config.activeWebpack}`,
-      },
-      homepage: `https://github.com/${repository}`,
-      repository: `https://github.com/${repository}`,
-      bugs: `https://github.com/${repository}/issues`,
       'pre-commit': 'lint-staged',
       'lint-staged': {
         '*.js': ['eslint --fix', 'git add'],


### PR DESCRIPTION
This PR updates both the `package.json` in the repo for the module _and_ the package template copied to repos that use `webpack-defaults`. The update is a highly semantic and uses an ordering that is meant to draw attention to the most important bits of a package's metadata first. 