### PR TITLE
ci: disable canary builds, @next is behind @latest

### DIFF
--- a/templates/.circleci/config.yml
+++ b/templates/.circleci/config.yml
@@ -10,21 +10,21 @@ unit_tests: &unit_tests
     - run:
         name: Run unit tests.
         command: npm run ci:test
-canary_tests: &canary_tests
-  steps:
-    - checkout
-    - setup_remote_docker
-    - restore_cache:
-        key: dependency-cache-{{ checksum "package-lock.json" }}
-    - run:
-        name: NPM Rebuild
-        command: npm install
-    - run:
-        name: Install Webpack Canary
-        command: npm i --no-save webpack@next
-    - run:
-        name: Run unit tests.
-        command: npm run ci:test
+# canary_tests: &canary_tests
+#   steps:
+#     - checkout
+#     - setup_remote_docker
+#     - restore_cache:
+#         key: dependency-cache-{{ checksum "package-lock.json" }}
+#     - run:
+#         name: NPM Rebuild
+#         command: npm install
+#     - run:
+#         name: Install Webpack Canary
+#         command: npm i --no-save webpack@next
+#     - run:
+#         name: Run unit tests.
+#         command: npm run ci:test
 
 version: 2
 jobs:
@@ -70,10 +70,10 @@ jobs:
     docker:
       - image: webpackcontrib/circleci-node9:latest
     <<: *unit_tests
-  node8-canary:
-    docker:
-      - image: webpackcontrib/circleci-node8:latest
-    <<: *canary_tests
+  # node8-canary:
+  #   docker:
+  #     - image: webpackcontrib/circleci-node8:latest
+  #   <<: *canary_tests
   analysis:
     docker:
       - image: webpackcontrib/circleci-node-base:latest
@@ -144,13 +144,13 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - node8-canary:
-          requires:
-            - analysis
-            - node6-latest
-          filters:
-            tags:
-              only: /.*/
+      # - node8-canary:
+      #     requires:
+      #       - analysis
+      #       - node6-latest
+      #     filters:
+      #       tags:
+      #         only: /.*/
       - publish:
           requires:
             - node8-latest


### PR DESCRIPTION
Note: As of this commit, webpack@next is still beta and several
minor versions behind webpack@latest. this is causing test failures
and should be disbled (commented out) until the next round of @next
testing commences.

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
