### PR TITLE
fix: add keywords to package, replace name in issue template

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,17 +1,18 @@
 {
-    "tasks": [
-        "templates",
-        "readme",
-        "git",
-        "babel",
-        "eslint",
-        "package",
-        "codecov"
-    ],
-    "webpackVersion": "latest",
-    "maintWebpack": "3.0.0",
-    "activeWebpack": "4.0.0",
-    "maintLTS": "6.9.0",
-    "activeLTS": "8.9.0",
-    "current": "9"
+  "tasks": [
+    "babel",
+    "codecov",
+    "eslint",
+    "git",
+    "issue_template",
+    "package",
+    "readme",
+    "templates"
+  ],
+  "webpackVersion": "latest",
+  "maintWebpack": "3.0.0",
+  "activeWebpack": "4.0.0",
+  "maintLTS": "6.9.0",
+  "activeLTS": "8.9.0",
+  "current": "9"
 }

--- a/src/tasks/issue_template.js
+++ b/src/tasks/issue_template.js
@@ -1,0 +1,16 @@
+const path = require('path');
+const { json, template } = require('mrm-core');
+
+module.exports = () => {
+  const pkg = json('package.json');
+
+  // Create README.md (no update)
+  const file = template(
+    '.github/ISSUE_TEMPLATE.md',
+    path.join(__dirname, '../../templates/.gitub/ISSUE_TEMPLATE.md')
+  );
+
+  if (!file.exists()) {
+    file.apply({ package: pkg.get('name') }).save();
+  }
+};

--- a/src/tasks/package.js
+++ b/src/tasks/package.js
@@ -92,6 +92,7 @@ module.exports = (config) => {
         defaults: 'webpack-defaults',
       },
       files: existing.files || ['dist/', 'lib/', 'index.js'],
+      keywords: existing.keywords || ['webpack'],
       peerDependencies: existing.peerDependencies || { webpack: '^4.3.0' },
       dependencies: existing.dependencies || {},
       devDependencies: existing.devDependencies || {},

--- a/src/tasks/templates.js
+++ b/src/tasks/templates.js
@@ -6,7 +6,6 @@ const { copyFiles } = require('mrm-core');
 const files = [
   '.circleci/config.yml',
   '.github/CODEOWNERS',
-  '.github/ISSUE_TEMPLATE.md',
   '.github/PULL_REQUEST_TEMPLATE.md',
   '.vscode/launch.json',
   '.editorconfig',

--- a/templates/.github/ISSUE_TEMPLATE.md
+++ b/templates/.github/ISSUE_TEMPLATE.md
@@ -13,7 +13,7 @@
 * Node Version:
 * NPM Version:
 * webpack Version:
-* webpack-serve Version:
+* ${package} Version:
 
 <!-- Please place an x (no spaces!) in all [ ] that apply -->
 


### PR DESCRIPTION
Fixes missed `keywords` in package.json.
Replaces package name in `ISSUE_TEMPLATE` (It's current static as `webpack-serve`, which isn't right)
