### PR TITLE
fix(package): copy existing bin property

### DIFF
--- a/src/tasks/package.js
+++ b/src/tasks/package.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 const path = require('path');
+
 const meta = require('user-meta');
 const gitUsername = require('git-username');
 const { json, install } = require('mrm-core');
@@ -61,6 +62,7 @@ module.exports = (config) => {
       author: existing.author || `${name}`,
       homepage: `https://github.com/${repository}`,
       bugs: `https://github.com/${repository}/issues`,
+      bin: existing.bin || '',
       main: existing.main || 'dist/cjs.js',
       engines: {
         node: `>= ${config.maintLTS} || >= ${config.activeLTS}`,


### PR DESCRIPTION
On the surface it may not seem like copying a `bin` property would be useful. But defaults comes packed with a lot of added bonus in linting, process, etc. that non-loaders, non-plugins can and should benefit from.
