### PR TITLE
Add badge for npm install size

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![test][test]][test-url]
 [![coverage][cover]][cover-url]
 [![chat][chat]][chat-url]
-[![size][size]][size-url]
 
 <div align="center">
   <a href="https://webpack.js.org/">
@@ -57,6 +56,3 @@ Any time you want to sync your project with the defaults, update this dependency
 
 [cover]: https://codecov.io/gh/webpack-contrib/webpack-defaults/branch/master/graph/badge.svg
 [cover-url]: https://codecov.io/gh/webpack-contrib/webpack-defaults
-
-[size]: https://packagephobia.now.sh/badge?p=webpack-defaults
-[size-url]: (https://packagephobia.now.sh/result?p=webpack-defaults

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![test][test]][test-url]
 [![coverage][cover]][cover-url]
 [![chat][chat]][chat-url]
+[![size][size]][size-url]
 
 <div align="center">
   <a href="https://webpack.js.org/">
@@ -56,3 +57,6 @@ Any time you want to sync your project with the defaults, update this dependency
 
 [cover]: https://codecov.io/gh/webpack-contrib/webpack-defaults/branch/master/graph/badge.svg
 [cover-url]: https://codecov.io/gh/webpack-contrib/webpack-defaults
+
+[size]: https://packagephobia.now.sh/badge?p=webpack-defaults
+[size-url]: (https://packagephobia.now.sh/result?p=webpack-defaults

--- a/templates/README.md
+++ b/templates/README.md
@@ -9,6 +9,7 @@
 [![deps][deps]][deps-url]
 [![tests][tests]][tests-url]
 [![chat][chat]][chat-url]
+[![size][size]][size-url]
 
 # ${package}
 
@@ -143,3 +144,6 @@ Please take a moment to read our contributing guidelines if you haven't yet done
 
 [chat]: https://img.shields.io/badge/gitter-webpack%2Fwebpack-brightgreen.svg
 [chat-url]: https://gitter.im/webpack/webpack
+
+[size]: https://packagephobia.now.sh/badge?p=${package}
+[size-url]: (https://packagephobia.now.sh/result?p=${package}


### PR DESCRIPTION
This adds a badge to the readme with the install size.

Related: https://github.com/webpack-contrib/webpack-command/pull/9