### PR TITLE
Fix hyperlink to size badge

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -146,4 +146,4 @@ Please take a moment to read our contributing guidelines if you haven't yet done
 [chat-url]: https://gitter.im/webpack/webpack
 
 [size]: https://packagephobia.now.sh/badge?p=${package}
-[size-url]: (https://packagephobia.now.sh/result?p=${package}
+[size-url]: https://packagephobia.now.sh/result?p=${package}


### PR DESCRIPTION
@shellscape There was a typo from #113 (oops)