### PR TITLE
chore: add Node.js 10 image

### DIFF
--- a/templates/.circleci/config.yml
+++ b/templates/.circleci/config.yml
@@ -66,6 +66,10 @@ jobs:
     docker:
       - image: webpackcontrib/circleci-node9:latest
     <<: *unit_tests
+  node10-latest:
+    docker:
+      - image: webpackcontrib/circleci-node10:latest
+    <<: *unit_tests
   node8-canary:
     docker:
       - image: webpackcontrib/circleci-node8:latest
@@ -138,6 +142,13 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - node10-latest:
+          requires:
+            - analysis
+            - node6-latest
+          filters:
+            tags:
+              only: /.*/
       - node8-canary:
           requires:
             - analysis
@@ -150,6 +161,7 @@ workflows:
             - node8-latest
             - node8-canary
             - node9-latest
+            - node10-latest
           filters:
             branches:
               only:

--- a/templates/.circleci/config.yml
+++ b/templates/.circleci/config.yml
@@ -62,9 +62,6 @@ jobs:
     docker:
       - image: webpackcontrib/circleci-node6:latest
     <<: *unit_tests
-  node9-latest:
-    docker:
-      - image: webpackcontrib/circleci-node9:latest
     <<: *unit_tests
   node10-latest:
     docker:
@@ -135,13 +132,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - node9-latest:
-          requires:
-            - analysis
-            - node6-latest
-          filters:
-            tags:
-              only: /.*/
       - node10-latest:
           requires:
             - analysis
@@ -160,7 +150,6 @@ workflows:
           requires:
             - node8-latest
             - node8-canary
-            - node9-latest
             - node10-latest
           filters:
             branches:


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

This adds the Node.js 10 image to the default configurations.
Reference: https://github.com/webpack-contrib/mini-css-extract-plugin/pull/136#issuecomment-388033026