### PR TITLE
chore: scope the package, sync readme with template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,124 @@
+## Contributing in @webpack-contrib
+
+We'd always love contributions to further improve the webpack / webpack-contrib ecosystem!
+Here are the guidelines we'd like you to follow:
+
+* [Questions and Problems](#question)
+* [Issues and Bugs](#issue)
+* [Feature Requests](#feature)
+* [Pull Request Submission Guidelines](#submit-pr)
+* [Commit Message Conventions](#commit)
+
+### <a name="question"></a> Got a Question or Problem?
+
+Please submit support requests and questions to StackOverflow using the tag [[webpack]](http://stackoverflow.com/tags/webpack).
+StackOverflow is better suited for this kind of support though you may also inquire in [Webpack Gitter](https://gitter.im/webpack/webpack).
+The issue tracker is for bug reports and feature discussions.
+
+### <a name="issue"></a> Found an Issue or Bug?
+
+Before you submit an issue, please search the issue tracker, maybe an issue for your problem already exists and the discussion might inform you of workarounds readily available.
+
+We want to fix all the issues as soon as possible, but before fixing a bug we need to reproduce and confirm it. In order to reproduce bugs, we ask that you to provide a minimal reproduction scenario (github repo or failing test case). Having a live, reproducible scenario gives us a wealth of important information without going back & forth to you with additional questions like:
+
+- version of Webpack used
+- version of the loader / plugin you are creating a bug report for
+- the use-case that fails
+
+A minimal reproduce scenario allows us to quickly confirm a bug (or point out config problems) as well as confirm that we are fixing the right problem.
+
+We will be insisting on a minimal reproduce scenario in order to save maintainers time and ultimately be able to fix more bugs. We understand that sometimes it might be hard to extract essentials bits of code from a larger code-base but we really need to isolate the problem before we can fix it.
+
+Unfortunately, we are not able to investigate / fix bugs without a minimal reproduction, so if we don't hear back from you we are going to close an issue that doesn't have enough info to be reproduced.
+
+### <a name="feature"></a> Feature Requests?
+
+You can *request* a new feature by creating an issue on Github.
+
+If you would like to *implement* a new feature, please submit an issue with a proposal for your work `first`, to be sure that particular makes sense for the project.
+
+### <a name="submit-pr"></a> Pull Request Submission Guidelines
+
+Before you submit your Pull Request (PR) consider the following guidelines:
+
+- Search Github for an open or closed PR that relates to your submission. You don't want to duplicate effort.
+- Commit your changes using a descriptive commit message that follows our [commit message conventions](#commit). Adherence to these conventions is necessary because release notes are automatically generated from these messages.
+- Fill out our `Pull Request Template`. Your pull request will not be considered if it is ignored.
+- Please sign the `Contributor License Agreement (CLA)` when a pull request is opened. We cannot accept your pull request without this. Make sure you sign with the primary email address associated with your local / github account.
+
+### <a name="commit"></a> Webpack Contrib Commit Conventions
+
+Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
+format that includes a **type**, a **scope** and a **subject**:
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+The **header** is mandatory and the **scope** of the header is optional.
+
+Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
+to read on GitHub as well as in various git tools.
+
+The footer should contain a [closing reference to an issue](https://help.github.com/articles/closing-issues-via-commit-messages/) if any.
+
+Examples:
+```
+docs(readme): update install instructions
+```
+```
+fix: refer to the `entrypoint` instead of the first `module`
+```
+
+#### Revert
+If the commit reverts a previous commit, it should begin with `revert: `, followed by the header of the reverted commit.
+In the body it should say: `This reverts commit <hash>.`, where the hash is the SHA of the commit being reverted.
+
+#### Type
+Must be one of the following:
+
+* **build**: Changes that affect the build system or external dependencies (example scopes: babel, npm)
+* **chore**: Changes that fall outside of build / docs that do not effect source code (example scopes: package, defaults)
+* **ci**: Changes to our CI configuration files and scripts (example scopes: circleci, travis)
+* **docs**: Documentation only changes (example scopes: readme, changelog)
+* **feat**: A new feature
+* **fix**: A bug fix
+* **perf**: A code change that improves performance
+* **refactor**: A code change that neither fixes a bug nor adds a feature
+* **revert**: Used when reverting a committed change
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons)
+* **test**: Addition of or updates to Jest tests
+
+#### Scope
+The scope is subjective & depends on the `type` see above. A good example would be a change to a particular class / module.
+
+#### Subject
+The subject contains a succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize the first letter
+* no dot (.) at the end
+
+#### Body
+Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
+The body should include the motivation for the change and contrast this with previous behavior.
+
+#### Footer
+The footer should contain any information about **Breaking Changes** and is also the place to
+reference GitHub issues that this commit **Closes**.
+
+**Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines. The rest of the commit message is then used for this.
+
+Example
+
+```
+BREAKING CHANGE: Updates to `Chunk.mapModules`.
+
+This release is not backwards compatible with `Webpack 2.x` due to breaking changes in webpack/webpack#4764
+Migration: see webpack/webpack#5225
+
+```

--- a/README.md
+++ b/README.md
@@ -1,58 +1,66 @@
-[![npm][npm]][npm-url]
-[![deps][deps]][deps-url]
-[![test][test]][test-url]
-[![coverage][cover]][cover-url]
-[![chat][chat]][chat-url]
-
 <div align="center">
-  <a href="https://webpack.js.org/">
-    <img width="200" height="200" vspace="" hspace="25" src="https://cdn.rawgit.com/webpack/media/e7485eb2/logo/icon-square-big.svg">
+  <a href="https://github.com/webpack/webpack">
+    <img width="200" height="200" src="https://webpack.js.org/assets/icon-square-big.svg">
   </a>
-  <h1>webpack-defaults</h1>
-  <p>Defaults to be shared across webpack projects</p>
 </div>
 
-<h2 align="center">Install</h2>
+[![npm][npm]][npm-url]
+[![node][node]][node-url]
+[![deps][deps]][deps-url]
+[![tests][tests]][tests-url]
+[![chat][chat]][chat-url]
+[![size][size]][size-url]
 
-```bash
-npm install --save-dev webpack-defaults
+# webpack-defaults
+
+Project configuration and boilerplate defaults for webpack projects
+
+## Requirements
+
+This module requires a minimum of Node v6.9.0 and Webpack v4.0.0.
+
+## Getting Started
+
+To begin, you'll need to install `webpack-defaults`:
+
+```console
+$ npm install @webpack-contrib/defaults --save-dev
 ```
 
-This will write a npm script you can run through
+After install a `defaults` NPM script will be written to the local
+`package.json`. To sync a project with webpack-defaults, simply run:
 
-```bash
+```
 npm run defaults
 ```
 
-Any time you want to sync your project with the defaults, update this dependency and run the command again.
+## Contributing
 
-<h2 align="center">Maintainers</h2>
+Please take a moment to read our contributing guidelines if you haven't yet done so.
 
-<table>
-  <tbody>
-    <tr>
-      <td align="center">
-        <a href="https://github.com/sapegin">
-          <img width="150" height="150" src="https://avatars.githubusercontent.com/u/70067?v=3">
-          </br>
-          Artem Sapegin
-        </a>
-      </td>
-    </tr>
-  <tbody>
-</table>
+#### [CONTRIBUTING](./.github/CONTRIBUTING)
+
+## License
+
+#### [MIT](./LICENSE)
 
 [npm]: https://img.shields.io/npm/v/webpack-defaults.svg
 [npm-url]: https://npmjs.com/package/webpack-defaults
 
+[node]: https://img.shields.io/node/v/webpack-defaults.svg
+[node-url]: https://nodejs.org
+
 [deps]: https://david-dm.org/webpack-contrib/webpack-defaults.svg
 [deps-url]: https://david-dm.org/webpack-contrib/webpack-defaults
+
+[tests]: 	https://img.shields.io/circleci/project/github/webpack-contrib/webpack-defaults.svg
+[tests-url]: https://circleci.com/gh/webpack-contrib/webpack-defaults
+
+[cover]: https://codecov.io/gh/webpack-contrib/webpack-defaults/branch/master/graph/badge.svg
+[cover-url]: https://codecov.io/gh/webpack-contrib/webpack-defaults
 
 [chat]: https://img.shields.io/badge/gitter-webpack%2Fwebpack-brightgreen.svg
 [chat-url]: https://gitter.im/webpack/webpack
 
-[test]: http://img.shields.io/travis/webpack-contrib/webpack-defaults.svg
-[test-url]: https://travis-ci.org/webpack-contrib/webpack-defaults
-
-[cover]: https://codecov.io/gh/webpack-contrib/webpack-defaults/branch/master/graph/badge.svg
-[cover-url]: https://codecov.io/gh/webpack-contrib/webpack-defaults
+[size]: https://packagephobia.now.sh/badge?p=webpack-defaults
+[size-url]: https://packagephobia.now.sh/result?p=webpack-defaults

--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
     "prettier": "^1.9.2",
     "standard-version": "^4.2.0"
   },
+  "jest": {
+    "testEnvironment": "node"
+  },
   "pre-commit": "lint-staged",
   "lint-staged": {
     "*.js": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
-  "name": "webpack-defaults",
+  "name": "@webpack-contrib/defaults",
   "version": "2.4.0",
-  "description": "Defaults to be shared across webpack projects",
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "Project configuration and boilerplate defaults for webpack projects",
   "license": "MIT",
   "repository": "webpack-contrib/webpack-defaults",
   "author": {

--- a/src/tasks/package.js
+++ b/src/tasks/package.js
@@ -97,6 +97,7 @@ module.exports = (config) => {
       dependencies: existing.dependencies || {},
       devDependencies: existing.devDependencies || {},
       keywords: existing.keywords || ['webpack'],
+      jest: { testEnvironment: 'node' },
       'pre-commit': 'lint-staged',
       'lint-staged': {
         '*.js': ['eslint --fix', 'git add'],


### PR DESCRIPTION
This PR changes the following:

1. Syncs the README with the template README we apply to other contrib repos. Fixes some broken images, links along the way. (Note: we removed the contributor avatars in the template readme some time ago)
2. Adds CONTRIBUTING.md to the root .github directory (it should be there), which matches the template.
3. Changes the package to a scoped NPM name. See below.

It was decided some time ago that packages which only have relevant use within webpack-contrib/webpack and not outside of the org or the orgs packages, should be scoped. The first package to adopt this new mantra was config-loader. Packages which aren't intended for public consumption but are utility, or auxiliary packages also apply. That makes webpack-defaults qualify.