### PR TITLE
ci: add `node >= v10.0.0` and skip canary testing on outdated versions

### DIFF
--- a/templates/.circleci/config.yml
+++ b/templates/.circleci/config.yml
@@ -66,9 +66,9 @@ jobs:
     docker:
       - image: webpackcontrib/circleci-node10:latest
     <<: *unit_tests
-  node8-canary:
+  node10-canary:
     docker:
-      - image: webpackcontrib/circleci-node8:latest
+      - image: webpackcontrib/circleci-node10:latest
     <<: *canary_tests
   analysis:
     docker:
@@ -106,7 +106,6 @@ jobs:
           name: Publish to NPM
           command: printf "noop running conventional-github-releaser"
 
-version: 2.0
 workflows:
   version: 2
   validate-publish:
@@ -138,7 +137,7 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - node8-canary:
+      - node10-canary:
           requires:
             - analysis
             - node6-latest
@@ -148,8 +147,8 @@ workflows:
       - publish:
           requires:
             - node8-latest
-            - node8-canary
             - node10-latest
+            - node10-canary
           filters:
             branches:
               only:

--- a/templates/appveyor.yml
+++ b/templates/appveyor.yml
@@ -6,13 +6,16 @@ init:
   - git config --global core.autocrlf input
 environment:
   matrix:
+    - nodejs_version: '10'
+      webpack_version: latest
+      job_part: test
     - nodejs_version: '8'
       webpack_version: latest
       job_part: test
     - nodejs_version: '6'
       webpack_version: latest
       job_part: test
-    - nodejs_version: '8'
+    - nodejs_version: '10'
       webpack_version: next
       job_part: test
 build: 'off'
@@ -27,4 +30,5 @@ before_test:
 test_script:
   - node --version
   - npm --version
-  - cmd: npm run ci:%job_part%
+  - cmd: FOR /F %%I in ('compver --name webpack --gte %webpack_version% --lt latest') do SET COMPARED_VERSION_RESULT=%%I
+  - cmd: IF %COMPARED_VERSION_RESULT% NEQ -1 (npm run ci:%job_part%) ELSE (ECHO "Next is older than Latest - Skipping Canary Suite")


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
:star: 