### PR TITLE
feat: use latest `npm` and `npm audit` instead `nsp`

### DIFF
--- a/src/tasks/package.js
+++ b/src/tasks/package.js
@@ -9,7 +9,6 @@ const packages = ['schema-utils', 'loader-utils'];
 
 const devPackages = [
   // Utilities
-  'nsp',
   'del',
   'del-cli',
   'cross-env',
@@ -84,7 +83,7 @@ module.exports = (config) => {
         'release:ci': 'conventional-github-releaser -p angular',
         'release:validate':
           'commitlint --from=$(git describe --tags --abbrev=0) --to=$(git rev-parse HEAD)',
-        security: 'nsp check',
+        security: 'npm audit',
         test: 'jest',
         'test:watch': 'jest --watch',
         'test:coverage': "jest --collectCoverageFrom='src/**/*.js' --coverage",


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
fixes #123
