### PR TITLE
fix: install `tag-versions` for `canary` tests

### DIFF
--- a/templates/appveyor.yml
+++ b/templates/appveyor.yml
@@ -25,6 +25,7 @@ install:
   - ps: Install-Product node $env:nodejs_version x64
   - npm i -g npm@latest
   - npm install
+  - npm i -g @webpack-contrib/tag-versions
 before_test:
   - cmd: npm install webpack@%webpack_version%
 test_script:


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
