### PR TITLE
ci: refactor setup

### DIFF
--- a/src/tasks/package.js
+++ b/src/tasks/package.js
@@ -9,7 +9,6 @@ const packages = ['schema-utils', 'loader-utils'];
 
 const devPackages = [
   // Utilities
-  'nsp',
   'del',
   'del-cli',
   'cross-env',
@@ -84,7 +83,7 @@ module.exports = (config) => {
         'release:ci': 'conventional-github-releaser -p angular',
         'release:validate':
           'commitlint --from=$(git describe --tags --abbrev=0) --to=$(git rev-parse HEAD)',
-        security: 'nsp check',
+        security: 'npm audit',
         test: 'jest',
         'test:watch': 'jest --watch',
         'test:coverage': "jest --collectCoverageFrom='src/**/*.js' --coverage",

--- a/templates/.circleci/config.yml
+++ b/templates/.circleci/config.yml
@@ -4,10 +4,14 @@ unit_tests: &unit_tests
     - restore_cache:
         key: dependency-cache-{{ checksum "package-lock.json" }}
     - run:
-        name: NPM Rebuild
-        command: npm install
+        name: Install Latest NPM.
+        # npm@3 is buggy
+        command: if [[ $(npm -v | cut -c -1) > 3 ]] ; then npm i -g npm@latest; else echo "Skip npm updating"; fi
     - run:
-        name: Run unit tests.
+        name: NPM Install.
+        command: npm ci || npm i
+    - run:
+        name: Run Test.
         command: npm run ci:test
 canary_tests: &canary_tests
   steps:
@@ -15,14 +19,17 @@ canary_tests: &canary_tests
     - restore_cache:
         key: dependency-cache-{{ checksum "package-lock.json" }}
     - run:
-        name: NPM Rebuild
-        command: npm install
+        name: Install Latest NPM.
+        command: npm i -g npm@latest
     - run:
-        name: Install Webpack Canary
+        name: NPM Install.
+        command: npm ci
+    - run:
+        name: Install Webpack Canary.
         command: npm i --no-save webpack@next
     - run:
-        name: Run unit tests.
-        command: if [[ $(compver --name webpack --gte next --lt latest) < 1 ]] ; then printf "Next is older than Latest - Skipping Canary Suite"; else npm run ci:test ; fi
+        name: Run Test.
+        command: if [[ $(compver --name webpack --gte next --lt latest) < 1 ]] ; then printf "Next is older than Latest - Skipping Canary Suite"; else npm run ci:test; fi
 
 version: 2
 jobs:
@@ -34,38 +41,43 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
-          name: Install Dependencies
-          command: npm install
+          name: Install Latest NPM.
+          command: npm i -g npm@latest
+      - run:
+          name: NPM Install.
+          command: npm ci
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:
             - ./node_modules
-
+  node6-latest:
+    docker:
+      - image: webpackcontrib/circleci-node6:latest
+    <<: *unit_tests
   node8-latest:
     docker:
       - image: webpackcontrib/circleci-node8:latest
+    <<: *unit_tests
+  node10-latest:
+    docker:
+      - image: webpackcontrib/circleci-node10:latest
     steps:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
-          name: NPM Rebuild
-          command: npm install
+          name: Install Latest NPM.
+          command: npm i -g npm@latest
       - run:
-          name: Run unit tests.
+          name: NPM Install.
+          command: npm ci
+      - run:
+          name: Run Test.
           command: npm run ci:coverage
       - run:
           name: Submit coverage data to codecov.
           command: bash <(curl -s https://codecov.io/bash)
           when: on_success
-  node6-latest:
-    docker:
-      - image: webpackcontrib/circleci-node6:latest
-    <<: *unit_tests
-  node10-latest:
-    docker:
-      - image: webpackcontrib/circleci-node10:latest
-    <<: *unit_tests
   node10-canary:
     docker:
       - image: webpackcontrib/circleci-node10:latest
@@ -78,46 +90,33 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
-          name: NPM Rebuild
-          command: npm install
+          name: Install Latest NPM.
+          command: npm i -g npm@latest
+      - run:
+          name: NPM Install.
+          command: npm ci
       - run:
           name: Run linting.
           command: npm run lint
       - run:
-          name: Run NSP Security Check.
+          name: Run NPM Audit.
           command: npm run security
       - run:
-          name: Validate Commit Messages
+          name: Validate Commit Messages.
           command: npm run ci:lint:commits
-  publish:
-    docker:
-      - image: webpackcontrib/circleci-node-base:latest
-    steps:
-      - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-      - run:
-          name: NPM Rebuild
-          command: npm install
-      # - run:
-      #     name: Validate Commit Messages
-      #     command: npm run release:validate
-      - run:
-          name: Publish to NPM
-          command: printf "noop running conventional-github-releaser"
 
 workflows:
   version: 2
-  validate-publish:
+  test:
     jobs:
       - dependency_cache
-      - node6-latest:
+      - analysis:
           requires:
             - dependency_cache
           filters:
             tags:
               only: /.*/
-      - analysis:
+      - node6-latest:
           requires:
             - dependency_cache
           filters:
@@ -144,12 +143,3 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - publish:
-          requires:
-            - node8-latest
-            - node10-latest
-            - node10-canary
-          filters:
-            branches:
-              only:
-                - master


### PR DESCRIPTION
- use `npm audit` (it is require latest `npm`)
- remove `publish`
- use `npm@latest` where it is possible
- use `npm ci` where it is possible (it is very fast)
- fix some typos

### Issues

- Fixes #123