### PR TITLE
docs(README): remove `Requirements` section

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -16,10 +16,6 @@
 
 ${description}
 
-## Requirements
-
-This module requires a minimum of Node v6.9.0 and Webpack v4.0.0.
-
 ## Getting Started
 
 To begin, you'll need to install `${package}`:


### PR DESCRIPTION
We don't need this, `npm` already do error/warning if you `node` or `webpack` version is not compatibility. Also it is require rewrite this after updates.

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
