### PR TITLE
chore: remove unnecessary release npm scripts

### DIFF
--- a/src/tasks/package.js
+++ b/src/tasks/package.js
@@ -80,9 +80,6 @@ module.exports = (config) => {
         prebuild: 'npm run clean',
         prepublish: 'npm run build',
         release: 'standard-version',
-        'release:ci': 'conventional-github-releaser -p angular',
-        'release:validate':
-          'commitlint --from=$(git describe --tags --abbrev=0) --to=$(git rev-parse HEAD)',
         security: 'npm audit',
         test: 'jest',
         'test:watch': 'jest --watch',


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
