### PR TITLE
fix(tasks/package): switch from `webpack-defaults` to `@webpack-contrib/defaults`

### DIFF
--- a/src/tasks/package.js
+++ b/src/tasks/package.js
@@ -33,13 +33,16 @@ const devPackages = [
   'eslint',
   'eslint-plugin-import',
   'eslint-plugin-prettier',
-  '@webpack-contrib/eslint-config-webpack',
   'lint-staged',
   'pre-commit',
   'prettier',
 
   // Webpack
   'webpack',
+
+  // Webpack Contrib
+  '@webpack-contrib/defaults',
+  '@webpack-contrib/eslint-config-webpack',
 ];
 
 module.exports = (config) => {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

By default we should install `@webpack-contrib/defaults` otherwise `npm run defaults` doesn't work.
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

No
<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info

No