### PR TITLE
fix: fix error occurred when cli copy files and add compatible logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "cross-env NODE_ENV=production babel src -d dist --ignore \"src/**/*.test.js\" --copy-files",
     "clean": "del-cli dist",
     "commitlint": "commitlint --from=master",
-    "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+    "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --write --list-different",
     "lint:js": "eslint --cache src test",
     "lint": "npm-run-all -l -p \"lint:**\"",
     "prepare": "npm run build",
@@ -34,7 +34,8 @@
     "test:coverage": "cross-env NODE_ENV=test jest --collectCoverageFrom=\"src/**/*.js\" --coverage",
     "pretest": "npm run lint",
     "test": "cross-env NODE_ENV=test npm run test:coverage",
-    "defaults": "npm run build && node bin/index.js"
+    "defaults": "npm run build && node bin/index.js",
+    "postinstall": "node lib/post_install.js"
   },
   "files": [
     "bin",

--- a/src/tasks/package.js
+++ b/src/tasks/package.js
@@ -91,7 +91,8 @@ module.exports = () => {
         test: 'npm run test:coverage',
         prepare: 'npm run build',
         release: 'standard-version',
-        defaults: existing.scripts.defaults || 'webpack-defaults',
+        defaults:
+          (existing.scripts && existing.scripts.defaults) || 'webpack-defaults',
       },
       files: existing.files || ['dist/', 'lib/', 'index.js'],
       peerDependencies: existing.peerDependencies || {

--- a/src/tasks/templates.js
+++ b/src/tasks/templates.js
@@ -26,10 +26,20 @@ const files = [
 
 const testFiles = [
   'test/loader.test.js',
-  'test/options.test.js',
-  'test/fixtures/fixture.js',
+  'test/cjs.test.js',
+  'test/name-option.test.js',
+  'test/validate-options.test.js',
+  'test/fixtures/simple.js',
   'test/fixtures/foo.js',
-  'test/helpers/compiler.js',
+  'test/helpers/compile.js',
+  'test/helpers/execute.js',
+  'test/helpers/getCompiler.js',
+  'test/helpers/getErrors.js',
+  'test/helpers/getWarnings.js',
+  'test/helpers/index.js',
+  'test/helpers/normalizeErrors.js',
+  'test/helpers/readAsset.js',
+  'test/helpers/readAssets.js',
 ];
 
 // These files will be created only once


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**

### Motivation / Use-Case
I found some errors when i use webpack-defaults cli.
At first，when i run it in an empty directory(without existing package.json), it will fail。
```
/Users/bytedance/.nvm/versions/node/v12.16.3/lib/node_modules/@webpack-contrib/defaults/dist/tasks/package.js:67
      defaults: existing.scripts.defaults || 'webpack-defaults'
                                 ^

TypeError: Cannot read property 'defaults' of undefined
    at module.exports (/Users/bytedance/.nvm/versions/node/v12.16.3/lib/node_modules/@webpack-contrib/defaults/dist/tasks/package.js:67:34)
    at /Users/bytedance/.nvm/versions/node/v12.16.3/lib/node_modules/@webpack-contrib/defaults/dist/index.js:18:5
    at Array.forEach (<anonymous>)
    at webpackDefaults (/Users/bytedance/.nvm/versions/node/v12.16.3/lib/node_modules/@webpack-contrib/defaults/dist/index.js:15:9)
    at Object.<anonymous> (/Users/bytedance/.nvm/versions/node/v12.16.3/lib/node_modules/@webpack-contrib/defaults/bin/index.js:3:19)
    at Module._compile (internal/modules/cjs/loader.js:1133:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1153:10)
    at Module.load (internal/modules/cjs/loader.js:977:32)
    at Function.Module._load (internal/modules/cjs/loader.js:877:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:74:12)
```
Second，after i overcome the first problem by creating a package.json file, error show up when copy files.
```
Create test/loader.test.js
(node:79169) UnhandledPromiseRejectionWarning: MrmError: copyFiles: source file not found: /Users/bytedance/.nvm/versions/node/v12.16.3/lib/node_modules/@webpack-contrib/defaults/templates/test/options.test.js
    at /Users/bytedance/.nvm/versions/node/v12.16.3/lib/node_modules/@webpack-contrib/defaults/node_modules/mrm-core/src/fs.js:32:10
    at Array.forEach (<anonymous>)
    at copyFiles (/Users/bytedance/.nvm/versions/node/v12.16.3/lib/node_modules/@webpack-contrib/defaults/node_modules/mrm-core/src/fs.js:29:21)
    at /Users/bytedance/.nvm/versions/node/v12.16.3/lib/node_modules/@webpack-contrib/defaults/dist/tasks/templates.js:26:7
(node:79169) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:79169) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

Then，when i excute npm test, prettier will exit status 1 like that :
```
> test@1.0.0 lint:prettier /Users/bytedance/Documents/work/code/awebpack/test
> prettier "{**/*,*}.js" --list-different

.eslintrc.js
.prettierrc.js
babel.config.js
commitlint.config.js
husky.config.js
lint-staged.config.js
src/cjs.js
src/index.js
test/helpers/normalizeErrors.js
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! test@1.0.0 lint:prettier: `prettier "{**/*,*}.js" --list-different`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the test@1.0.0 lint:prettier script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/bytedance/.npm/_logs/2020-06-29T13_39_42_161Z-debug.log
```
 At last, i found it would't generator the script `defaults` in my local package.json

I have fixed all problems above.

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
