### PR TITLE
feat: copy missing or new test templates

### DIFF
--- a/src/tasks/templates.js
+++ b/src/tasks/templates.js
@@ -1,6 +1,5 @@
 const path = require('path');
 
-const pathExists = require('path-exists');
 const { copyFiles, json, template } = require('mrm-core');
 
 // These files will be overwritten without any confirmation
@@ -53,11 +52,7 @@ module.exports = () => {
 
   copyFiles(templatesDir, files);
 
-  pathExists('./test').then((exists) => {
-    if (!exists) {
-      copyFiles(templatesDir, testFiles, { overwrite: false });
-    }
-  });
+  copyFiles(templatesDir, testFiles, { overwrite: false });
 
   for (const tmpl of dynamicTemplates) {
     const file = template(


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

While fixing #190 I realised that rerunning `npm run defaults` would not re-copy the test templates. Perhaps that is why there were so many templates missing.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

Previously test files would only be copied once even if the module was upgraded and new templates were added. This means that people who had previously deleted unwanted test file files may have them reappear (although most have been replaced since 6.0.0 anyway).

### Additional Info
