### PR TITLE
chore: add funding field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "name": "Artem Sapegin",
     "url": "https://sapegin.me"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/webpack"
+  },
   "homepage": "https://github.com/webpack-contrib/webpack-defaults",
   "bugs": "https://github.com/webpack-contrib/webpack-defaults/issues",
   "bin": {


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Adds funding field to `package.json` to show fund this package button in npmjs.org. All other plugins and loaders have this 